### PR TITLE
Add Warning Messages for Adaptive QoS

### DIFF
--- a/flexqos.asp
+++ b/flexqos.asp
@@ -1185,6 +1185,7 @@ function get_data() {
 		success: function(response) {
 			redraw();
 			draw_conntrack_table();
+			check_bandwidth_flow();
 			timedEvent = setTimeout("get_data();", refreshRate * 1000);
 		}
 	});
@@ -1296,6 +1297,56 @@ function initialize_charts() {
 	});
 	line_obj_ul=line_obj;		// actually draws the chart on the page
 } // initialize_charts
+
+function getFwBase () {
+    /*  "3.0.0.6"  →  3006  */
+    const ver = document.getElementById('firmver')?.value || '';
+    return parseInt(ver.replace(/\./g, ''), 10);     // NaN if blank
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+    const fwBase = getFwBase();
+
+    const noflowMsg = (fwBase === 3006)
+        ? 'Adaptive&nbsp;QoS is not functioning correctly on '
+          + 'BE-series routers due to a known ASUS&nbsp;/&nbsp;Trend&nbsp;Micro issue. '
+          + 'Once ASUS resolves this, FlexQoS should work as expected.'
+        : 'Adaptive&nbsp;QoS appears to be malfunctioning. '
+          + 'FlexQoS cannot apply its rules while the underlying QoS system is malfunctioning.';
+
+    const span = document.getElementById('noflow_msg');
+    if (span) span.innerHTML = noflowMsg;
+});
+
+/* consider anything below this many *kilobits* per second “idle” */
+const NOFLOW_CUTOFF_KBPS = 1;      // feel free to raise/lower
+const NOFLOW_THRESHOLD   = 5;     // 5 × 3s refresh about 15 seconds
+
+let noFlowCounter = 0;
+
+function kbpsFromRateString(str) {
+    if (!str) return 0;
+    if (str.includes("Mbit"))  return parseFloat(str) * 1000;
+    if (str.includes("Kbit"))  return parseFloat(str);
+    return parseFloat(str) / 1000;
+}
+
+function check_bandwidth_flow () {
+    let dlRate = 0, ulRate = 0;
+
+    for (const e of tcdata_lan_array) dlRate += kbpsFromRateString(e[2]);
+    for (const e of tcdata_wan_array) ulRate += kbpsFromRateString(e[2]);
+
+    if (dlRate < NOFLOW_CUTOFF_KBPS && ulRate < NOFLOW_CUTOFF_KBPS) {
+        noFlowCounter++;
+    } else {
+        noFlowCounter = 0;
+    }
+
+    const warn = document.getElementById('noflow_notice');
+    warn.style.display = (noFlowCounter >= NOFLOW_THRESHOLD) ? 'block'
+                                                             : 'none';
+}
 
 function change_chart_scale(input) {
 	var chart_scale = cookie.get('flexqos_rate_graph_scale');
@@ -2743,7 +2794,7 @@ function DelCookie(cookiename){
 <iframe name="hidden_frame" id="hidden_frame" width="0" height="0" frameborder="0"></iframe>
 <form method="post" name="form" action="/start_apply.htm" target="hidden_frame">
 <input type="hidden" name="preferred_lang" id="preferred_lang" value="<% nvram_get(" preferred_lang "); %>">
-<input type="hidden" name="firmver" value="<% nvram_get(" firmver "); %>">
+<input type="hidden" name="firmver" id="firmver" value="<% nvram_get(" firmver "); %>">
 <input type="hidden" name="current_page" value="">
 <input type="hidden" name="next_page" value="">
 <input type="hidden" name="action_mode" value="apply">
@@ -2925,6 +2976,11 @@ function DelCookie(cookiename){
 </table>
 <br>
 <div id="no_aqos_notice" style="display:none;font-size:125%;color:#FFCC00;">Note: Adaptive QoS is not enabled.</div>
+<div id="noflow_notice"
+     style="display:none;font-size:125%;color:#FFCC00;">
+    No bandwidth flow detected.
+    <span id="noflow_msg"></span>
+</div>
 <table>
 <tr id="dl_tr">
 <td style="padding-right:10px;font-size:125%;color:#FFCC00;">

--- a/flexqos.sh
+++ b/flexqos.sh
@@ -44,7 +44,9 @@ readonly SCRIPTPATH="${ADDON_DIR}/${SCRIPTNAME}.sh"
 readonly LOCKFILE="/tmp/addonwebui.lock"
 # shellcheck disable=SC2155
 readonly fwInstalledBaseVers="$(nvram get firmver | sed 's/\.//g')"
+# shellcheck disable=SC2155
 readonly fwInstalledBuildVers="$(nvram get buildno)"
+# shellcheck disable=SC2155
 readonly fwInstalledExtendNum="$(nvram get extendno)"
 IPv6_enabled="$(nvram get ipv6_service)"
 

--- a/flexqos.sh
+++ b/flexqos.sh
@@ -42,6 +42,7 @@ readonly ADDON_DIR="/jffs/addons/${SCRIPTNAME}"
 readonly WEBUIPATH="${ADDON_DIR}/${SCRIPTNAME}.asp"
 readonly SCRIPTPATH="${ADDON_DIR}/${SCRIPTNAME}.sh"
 readonly LOCKFILE="/tmp/addonwebui.lock"
+# shellcheck disable=SC2155
 readonly fwInstalledBaseVers="$(nvram get firmver | sed 's/\.//g')"
 readonly fwInstalledBuildVers="$(nvram get buildno)"
 readonly fwInstalledExtendNum="$(nvram get extendno)"


### PR DESCRIPTION
Add Warning Messages for Adaptive QoS
If Adaptive QoS is not functional, display a warning message to the user in shell and the WebUI

![image](https://github.com/user-attachments/assets/eb45afd9-9684-4693-965a-817c6a075406)

![image](https://github.com/user-attachments/assets/09015785-cfd7-4473-8170-95ae1f66a884)
