### PR TITLE
FlexQoS 1.5.0 Release

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,6 @@
+v1.5.0 (08-Sep-2025)
+  - FIXED: Allow script versions with double-digit segments.
+
 v1.4.10 (08-Sep-2025)
   - FIXED: Adressed missing cleanup for any cron job schedules when uninstalling.
   - FIXED: Missing the ability to backup the new QoS schedules.

--- a/flexqos.sh
+++ b/flexqos.sh
@@ -12,7 +12,7 @@
 # Contributors: @maghuro
 # shellcheck disable=SC1090,SC1091,SC2039,SC2154,SC3043
 # amtm NoMD5check
-version=1.4.10
+version=1.5.0
 release=2025-09-06
 # Forked from FreshJR_QOS v8.8, written by FreshJR07 https://github.com/FreshJR07/FreshJR_QOS
 # License


### PR DESCRIPTION
FlexQoS 1.5.0 Release

<img width="773" height="418" alt="image" src="https://github.com/user-attachments/assets/24f3b3f7-5cf4-4c27-bb91-3229c59b9b52" />

Allow versions with double-digit segments