### PR TITLE
Develop 1.5.2 As Next Stable Release

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,5 +1,5 @@
 v1.5.1 (06-Sep-2025)
-  - FIXED: Properly compare version by using arithmetic conversation
+  - FIXED: Properly compare version by using arithmetic conversion
   - FIXED: Fixed new schedule keeping Flow Cache disabled when disabling QoS
 
 v1.5.0 (06-Sep-2025)

--- a/flexqos.asp
+++ b/flexqos.asp
@@ -3104,7 +3104,7 @@ function DelCookie(cookiename){
         <table width="100%" border="1" cellspacing="0" cellpadding="4" class="FormTable_table">
           <thead>
             <tr>
-              <td colspan="4">Add schedule window</td>
+              <td colspan="4">Add schedule</td>
             </tr>
           </thead>
           <tbody>

--- a/flexqos.sh
+++ b/flexqos.sh
@@ -12,8 +12,8 @@
 # Contributors: @maghuro
 # shellcheck disable=SC1090,SC1091,SC2039,SC2154,SC3043
 # amtm NoMD5check
-version=1.5.1
-release=2025-09-06
+version=1.5.2
+release=2025-09-27
 # Forked from FreshJR_QOS v8.8, written by FreshJR07 https://github.com/FreshJR07/FreshJR_QOS
 # License
 #  FlexQoS is free to use under the GNU General Public License, version 3 (GPL-3.0).
@@ -2275,12 +2275,7 @@ startup() {
 	install_webui mount
 	generate_bwdpi_arrays
 	get_config
-	qos_schedule_apply_from_config
-	if [ "$(nvram get qos_enable)" = "1" ]; then
-		_fc_apply_policy on
-	else
-		_fc_apply_policy off
-	fi
+	_fc_apply_policy on
 	_flush_conntrack_
 
 	cru d "${SCRIPTNAME}"_5min 2>/dev/null
@@ -2329,6 +2324,12 @@ startup() {
 		schedule_check_job
 	else
 		logmsg "No TC modifications necessary"
+	fi
+
+	qos_schedule_apply_from_config
+	if [ "$(nvram get qos_enable)" != "1" ]; then
+		_fc_apply_policy off
+		_flush_conntrack_
 	fi
 } # startup
 
@@ -2464,6 +2465,8 @@ needrestart=0		# initialize variable used in prompt_restart()
 case "${arg1}" in
 	'start'|'check')
 		logmsg "$0 (pid=$$) called in ${mode} mode with $# args: $*"
+		SCHEDULE="$(am_settings_get "${SCRIPTNAME}"_schedule)"
+		if [ -n "$SCHEDULE" ]; then qos_start; fi
 		startup
 		;;
 	'appdb')


### PR DESCRIPTION
Release Notes for FlexQoS 1.5.2 production release now available
[2025-Sep-30]

What's changed/new?
Resolved a bug which caused FlexQoS to fail the startup sequenece if the router rebooted while a QoS schedule had QoS disabled.
As reported by [maghuro](https://www.snbforums.com/members/maghuro.67697/)
[Bug-Fix](https://github.com/AMTM-OSR/FlexQoS/commit/a51fba381ad2d08310f7a45a2ac4a0069d443359)

The fork from [@dave14305](https://github.com/dave14305) 's repository is now hosted on the AMTM-OSR GitHub repo:
https://github.com/AMTM-OSR/FlexQoS